### PR TITLE
Rails5

### DIFF
--- a/calendar_date_select.gemspec
+++ b/calendar_date_select.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{calendar_date_select}
-  s.version = "1.16.3-rails5"
+  s.version = "1.16.3.rails5"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Shih-gian Lee", "Enrique Garcia Cota (kikito)", "Tim Charper", "Lars E. Hoeg"]

--- a/calendar_date_select.gemspec
+++ b/calendar_date_select.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{calendar_date_select}
-  s.version = "1.16.3"
+  s.version = "1.16.3-rails5"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Shih-gian Lee", "Enrique Garcia Cota (kikito)", "Tim Charper", "Lars E. Hoeg"]
@@ -78,7 +78,9 @@ Gem::Specification.new do |s|
      "spec/calendar_date_select/includes_helper_spec.rb",
      "spec/spec_helper.rb"
   ]
-  s.add_dependency 'prototype-rails'
+
+  # "prototype-rails" actually is a dependency but we are using a forked version (voxmedia/prototype-rails)
+  # s.add_dependency 'prototype-rails'
 
   if s.respond_to? :specification_version then
     current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION

--- a/lib/calendar_date_select/version.rb
+++ b/lib/calendar_date_select/version.rb
@@ -1,5 +1,5 @@
 module CalendarDateSelect
   module Rails
-    VERSION = "1.16.3"
+    VERSION = "1.16.3-rails5"
   end
 end

--- a/lib/calendar_date_select/version.rb
+++ b/lib/calendar_date_select/version.rb
@@ -1,5 +1,5 @@
 module CalendarDateSelect
   module Rails
-    VERSION = "1.16.3-rails5"
+    VERSION = "1.16.3.rails5"
   end
 end


### PR DESCRIPTION
Just remove the only offending dependecy (which we have an adequate replacement for already in chorus), and then bump the version (using weird notation but I think it makes sense here)